### PR TITLE
Fix CSRF token lookup for login

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,10 +5,6 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import Providers from "@/components/Providers";
 
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
-import Providers from "@/components/Providers";
-
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,10 +15,10 @@ export const authOptions: NextAuthOptions = {
         message: { label: "Message", type: "text" },
         signature: { label: "Signature", type: "text" },
       },
-      async authorize(credentials, req) {
+        async authorize(credentials, req) {
         try {
           const siwe = new SiweMessage(JSON.parse(credentials?.message || "{}"));
-          const csrf = (req?.headers?.["x-csrf-token"] as string) ?? "";
+          const csrf = (req?.body?.csrfToken as string) ?? "";
           const { success } = await siwe.verify({
             signature: credentials?.signature || "",
             domain: new URL(process.env.NEXTAUTH_URL ?? "http://localhost:3000").host,


### PR DESCRIPTION
## Summary
- handle CSRF token from request body when verifying SIWE messages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68401dfbdc9c8323855e55668bafc39a