### PR TITLE
Fix missing database tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ Create a `.env` file based on `.env.example` before starting the server:
 cp .env.example .env
 ```
 
-Set `NEXTAUTH_SECRET` to any random string.
+Set `NEXTAUTH_SECRET` to any random string. If you access the app through a
+non-localhost address, set `NEXTAUTH_URL` to that full URL. Otherwise the
+current request's host will be used for authentication.
+
+When you start the development server the first time, the Prisma schema will be
+applied automatically via `prisma migrate deploy`. This creates the `dev.db`
+SQLite database if it does not already exist.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
+    "dev": "prisma migrate deploy --schema=./prisma/schema.prisma && next dev --turbopack",
+    "build": "prisma migrate deploy --schema=./prisma/schema.prisma && next build",
+    "start": "prisma migrate deploy --schema=./prisma/schema.prisma && next start",
     "lint": "next lint",
     "prisma:generate": "prisma generate",
     "postinstall": "prisma generate"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,9 +19,12 @@ export const authOptions: NextAuthOptions = {
         try {
           const siwe = new SiweMessage(JSON.parse(credentials?.message || "{}"));
           const csrf = (req?.body?.csrfToken as string) ?? "";
+          const host =
+            req?.headers?.get("host") ??
+            new URL(process.env.NEXTAUTH_URL ?? "http://localhost:3000").host;
           const { success } = await siwe.verify({
             signature: credentials?.signature || "",
-            domain: new URL(process.env.NEXTAUTH_URL ?? "http://localhost:3000").host,
+            domain: host,
             nonce: csrf,
           });
           if (success) {


### PR DESCRIPTION
## Summary
- automatically apply Prisma migrations when starting dev/build/start
- document that the database will be created automatically on first run
- dynamically use request host for SIWE domain verification
- document how to override the default host

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840312d69148323bec4a5bdedd5b22e