### PR TITLE
Add profile view and edit pages

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -3,6 +3,16 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 import { NextResponse } from 'next/server';
 
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = (session.user as { id?: string }).id as string;
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  return NextResponse.json(user);
+}
+
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) {

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+import { useSession } from 'next-auth/react';
+import { useState, useEffect } from 'react';
+
+export default function ProfilePage() {
+  const { data: session } = useSession();
+  const [nickname, setNickname] = useState('');
+  const [bio, setBio] = useState('');
+  const [twitter, setTwitter] = useState('');
+  const [telegram, setTelegram] = useState('');
+  const [website, setWebsite] = useState('');
+  const [donationAddress, setDonationAddress] = useState('');
+
+  useEffect(() => {
+    if (session?.user) {
+      setNickname(session.user.nickname ?? '');
+      setBio(session.user.bio ?? '');
+      setTwitter(session.user.twitter ?? '');
+      setTelegram(session.user.telegram ?? '');
+      setWebsite(session.user.website ?? '');
+      setDonationAddress(session.user.donationAddress ?? '');
+    }
+  }, [session]);
+
+  if (!session) return <p>Please login</p>;
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nickname, bio, twitter, telegram, website, donationAddress }),
+    });
+  }
+
+  return (
+    <div className="p-8 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold mb-4">Profile</h1>
+      <form className="flex flex-col gap-4" onSubmit={submit}>
+        <input
+          type="text"
+          placeholder="Nickname"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          className="border p-2"
+        />
+        <textarea
+          placeholder="Bio"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="text"
+          placeholder="Twitter"
+          value={twitter}
+          onChange={(e) => setTwitter(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="text"
+          placeholder="Telegram"
+          value={telegram}
+          onChange={(e) => setTelegram(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="text"
+          placeholder="Website"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="text"
+          placeholder="Donation address"
+          value={donationAddress}
+          onChange={(e) => setDonationAddress(e.target.value)}
+          className="border p-2"
+        />
+        <button type="submit" className="px-4 py-2 border rounded">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,74 +1,39 @@
-'use client';
-import { useSession } from 'next-auth/react';
-import { useState } from 'react';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import Image from 'next/image';
+import Link from 'next/link';
 
-export default function ProfilePage() {
-  const { data: session } = useSession();
-  const [nickname, setNickname] = useState('');
-  const [bio, setBio] = useState('');
-  const [twitter, setTwitter] = useState('');
-  const [telegram, setTelegram] = useState('');
-  const [website, setWebsite] = useState('');
-  const [donationAddress, setDonationAddress] = useState('');
+export default async function MyProfile() {
+  const session = await getServerSession(authOptions);
+  if (!session) return <p className="p-8">Please login</p>;
 
-  if (!session) return <p>Please login</p>;
-
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    await fetch('/api/profile', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ nickname, bio, twitter, telegram, website, donationAddress }),
-    });
-  }
+  const user = session.user as {
+    id: string;
+    name?: string | null;
+    image?: string | null;
+    nickname?: string | null;
+    bio?: string | null;
+    twitter?: string | null;
+    telegram?: string | null;
+    website?: string | null;
+  };
 
   return (
     <div className="p-8 max-w-xl mx-auto">
-      <h1 className="text-xl font-bold mb-4">Profile</h1>
-      <form className="flex flex-col gap-4" onSubmit={submit}>
-        <input
-          type="text"
-          placeholder="Nickname"
-          value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
-          className="border p-2"
-        />
-        <textarea
-          placeholder="Bio"
-          value={bio}
-          onChange={(e) => setBio(e.target.value)}
-          className="border p-2"
-        />
-        <input
-          type="text"
-          placeholder="Twitter"
-          value={twitter}
-          onChange={(e) => setTwitter(e.target.value)}
-          className="border p-2"
-        />
-        <input
-          type="text"
-          placeholder="Telegram"
-          value={telegram}
-          onChange={(e) => setTelegram(e.target.value)}
-          className="border p-2"
-        />
-        <input
-          type="text"
-          placeholder="Website"
-          value={website}
-          onChange={(e) => setWebsite(e.target.value)}
-          className="border p-2"
-        />
-        <input
-          type="text"
-          placeholder="Donation address"
-          value={donationAddress}
-          onChange={(e) => setDonationAddress(e.target.value)}
-          className="border p-2"
-        />
-        <button type="submit" className="px-4 py-2 border rounded">Save</button>
-      </form>
+      {user.image && (
+        <Image src={user.image} alt="avatar" width={80} height={80} className="rounded-full" />
+      )}
+      <h1 className="text-xl font-bold mt-4">{user.nickname || user.name || user.id}</h1>
+      {user.bio && <p className="mt-2">{user.bio}</p>}
+      {user.twitter && (
+        <p className="mt-2">Twitter: <a href={`https://twitter.com/${user.twitter}`}>{user.twitter}</a></p>
+      )}
+      {user.website && (
+        <p className="mt-2">Website: <a href={user.website}>{user.website}</a></p>
+      )}
+      <Link href="/profile/edit" className="inline-block mt-4 px-4 py-2 border rounded">
+        Редактировать
+      </Link>
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,7 +40,13 @@ export default function Header() {
     <header className="flex justify-between items-center p-4 border-b">
       <nav className="flex gap-4">
         <Link href="/">Home</Link>
-        {session && <Link href="/profile">Profile</Link>}
+        {session && (
+          session.user?.nickname ? (
+            <Link href="/profile">Мой профиль</Link>
+          ) : (
+            <Link href="/profile/edit">Создать</Link>
+          )
+        )}
       </nav>
       <div>
         {!session ? (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -85,10 +85,24 @@ export const authOptions: NextAuthOptions = {
      */
     async session({ session, token }) {
       if (token?.sub) {
+        const user = await prisma.user.findUnique({
+          where: { id: token.sub as string },
+          select: {
+            nickname: true,
+            bio: true,
+            twitter: true,
+            telegram: true,
+            website: true,
+            donationAddress: true,
+            image: true,
+            name: true,
+          },
+        });
         session.user = {
           ...(session.user ?? {}),
           id: token.sub as string,
-        } as DefaultUser & { id: string };
+          ...user,
+        } as DefaultUser & { id: string } & typeof user;
       }
       return session;
     },


### PR DESCRIPTION
## Summary
- expose profile data via `GET /api/profile`
- show "Мой профиль" or "Создать" menu item based on nickname
- preload profile data when editing
- add page to view current user's profile
- include profile fields in session data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840961592b48323bf9d3ebc83a8defe