### PR TITLE
Improve profile error handling and button styles

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -2,15 +2,24 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 import { NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const userId = (session.user as { id?: string }).id as string;
-  const user = await prisma.user.findUnique({ where: { id: userId } });
-  return NextResponse.json(user);
+  try {
+    const userId = (session.user as { id?: string }).id as string;
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
+    }
+    return NextResponse.json(user);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
 }
 
 export async function POST(request: Request) {
@@ -20,9 +29,20 @@ export async function POST(request: Request) {
   }
   const data = await request.json();
   const userId = (session.user as { id?: string }).id as string;
-  await prisma.user.update({
-    where: { id: userId },
-    data,
-  });
-  return NextResponse.json({ success: true });
+  try {
+    await prisma.user.update({
+      where: { id: userId },
+      data,
+    });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2025'
+    ) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
+    }
+    console.error(error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
 }

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -86,7 +86,7 @@ export default function ProfilePage() {
           onChange={(e) => setDonationAddress(e.target.value)}
           className="border p-2"
         />
-        <button type="submit" className="px-4 py-2 border rounded">Save</button>
+        <button type="submit" className="px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition">Save</button>
       </form>
     </div>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -37,7 +37,7 @@ export default async function MyProfile() {
       {user.website && (
         <p className="mt-2">Website: <a href={user.website}>{user.website}</a></p>
       )}
-      <Link href="/profile/edit" className="inline-block mt-4 px-4 py-2 border rounded">
+      <Link href="/profile/edit" className="inline-block mt-4 px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition">
         Редактировать
       </Link>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -50,7 +50,7 @@ export default function Header() {
       </nav>
       <div>
         {!session ? (
-          <button onClick={handleLogin} className="px-4 py-2 border rounded">
+          <button onClick={handleLogin} className="px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition">
             Login
           </button>
         ) : (
@@ -58,7 +58,7 @@ export default function Header() {
             {session.user?.image && (
               <Image src={session.user.image} alt="avatar" width={32} height={32} className="rounded-full" />
             )}
-            <button onClick={() => signOut()} className="px-4 py-2 border rounded">
+            <button onClick={() => signOut()} className="px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition">
               Logout
             </button>
           </div>


### PR DESCRIPTION
## Summary
- handle missing user profile in API route with proper errors
- style login, logout, edit and save buttons so state is obvious

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a6dbed2c8323bfb1a6ae5f60a5bc