### PR TITLE
Implement photo posts with editing and infinite scroll

### DIFF
--- a/prisma/migrations/20250605141053_add_post_model/migration.sql
+++ b/prisma/migrations/20250605141053_add_post_model/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Post" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "description" TEXT,
+    "tags" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Post_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Photo" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "postId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    CONSTRAINT "Photo_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,25 +4,45 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
   previewFeatures = ["strictUndefinedChecks"]
 }
 
 model User {
-  id            String    @id @default(cuid())
-  name          String?
-  email         String?   @unique
-  emailVerified DateTime?
-  image         String?
-  nickname      String?
-  bio           String?
-  twitter       String?
-  telegram      String?
-  website       String?
+  id              String          @id @default(cuid())
+  name            String?
+  email           String?         @unique
+  emailVerified   DateTime?
+  image           String?
+  nickname        String?
+  bio             String?
+  twitter         String?
+  telegram        String?
+  website         String?
   donationAddress String?
-  accounts      Account[]
-  sessions      Session[]
-  Authenticator Authenticator[]
+  accounts        Account[]
+  sessions        Session[]
+  Authenticator   Authenticator[]
+  posts           Post[]
+}
+
+model Post {
+  id          String   @id @default(cuid())
+  userId      String
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  description String?
+  tags        String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  photos      Photo[]
+}
+
+model Photo {
+  id     String @id @default(cuid())
+  postId String
+  url    String
+
+  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
 }
 
 model Account {

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,0 +1,56 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { NextResponse, NextRequest } from 'next/server';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<Record<string, string>> }
+) {
+  const { id } = await params;
+  const post = await prisma.post.findUnique({
+    where: { id },
+    include: {
+      photos: true,
+      user: { select: { id: true, nickname: true, name: true, image: true } },
+    },
+  });
+  if (!post) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(post);
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<Record<string, string>> }
+) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = (session.user as { id: string }).id;
+  const data = await req.json();
+  try {
+    const post = await prisma.post.update({
+      where: { id, userId },
+      data: {
+        description: data.description ?? null,
+        tags: data.tags ?? null,
+        photos: {
+          deleteMany: {},
+          create: (data.photos as string[]).map((url: string) => ({ url })),
+        },
+      },
+      include: {
+        photos: true,
+        user: { select: { id: true, nickname: true, name: true, image: true } },
+      },
+    });
+    return NextResponse.json(post);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,51 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const cursor = searchParams.get('cursor');
+  const take = 10;
+  const posts = await prisma.post.findMany({
+    take: take + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    orderBy: { createdAt: 'desc' },
+    include: {
+      photos: true,
+      user: { select: { id: true, nickname: true, name: true, image: true } },
+    },
+  });
+  let nextCursor: string | undefined = undefined;
+  if (posts.length > take) {
+    const next = posts.pop();
+    nextCursor = next?.id;
+  }
+  return NextResponse.json({ posts, nextCursor });
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const data = await request.json();
+  const userId = (session.user as { id: string }).id;
+  try {
+    const post = await prisma.post.create({
+      data: {
+        userId,
+        description: data.description ?? null,
+        tags: data.tags ?? null,
+        photos: {
+          create: (data.photos as string[]).map((url: string) => ({ url })),
+        },
+      },
+      include: { photos: true, user: { select: { id: true, nickname: true, name: true, image: true } } },
+    });
+    return NextResponse.json(post);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,33 @@
-export default function Home() {
+import Link from 'next/link';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import PostsFeed from '@/components/PostsFeed';
+
+export default async function Home() {
+  const session = await getServerSession(authOptions);
+  const take = 10;
+  const posts = await prisma.post.findMany({
+    take,
+    orderBy: { createdAt: 'desc' },
+    include: {
+      photos: true,
+      user: { select: { id: true, nickname: true, name: true, image: true } },
+    },
+  });
+  const nextCursor = posts.length === take ? posts[posts.length - 1].id : undefined;
+
   return (
-    <section className="p-8">
-      <h1 className="text-2xl font-bold mb-4">Welcome to Ardents</h1>
-      <p>This is the home page.</p>
+    <section className="p-8 space-y-4">
+      {session && (
+        <Link
+          href="/posts/new"
+          className="px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600 inline-block"
+        >
+          Новый пост
+        </Link>
+      )}
+      <PostsFeed initialPosts={posts} initialCursor={nextCursor} currentUserId={(session?.user as { id?: string })?.id} />
     </section>
   );
 }

--- a/src/app/posts/[id]/edit/EditPostForm.tsx
+++ b/src/app/posts/[id]/edit/EditPostForm.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function EditPostPage({ params }: { params: { id: string } }) {
+  const [photos, setPhotos] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch(`/api/posts/${params.id}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!data) return;
+        setPhotos(data.photos.map((p: { url: string }) => p.url).join('\n'));
+        setDescription(data.description ?? '');
+        setTags(data.tags ?? '');
+      });
+  }, [params.id]);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const photoList = photos.split('\n').map((p) => p.trim()).filter(Boolean);
+    const res = await fetch(`/api/posts/${params.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photos: photoList, description, tags }),
+    });
+    if (res.ok) {
+      router.push('/');
+    }
+  }
+
+  return (
+    <div className="p-8 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold mb-4">Редактировать пост</h1>
+      <form className="flex flex-col gap-4" onSubmit={submit}>
+        <textarea
+          placeholder="Image URLs, one per line"
+          value={photos}
+          onChange={(e) => setPhotos(e.target.value)}
+          className="border p-2"
+        />
+        <textarea
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="text"
+          placeholder="Tags (comma separated)"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          className="border p-2"
+        />
+        <button type="submit" className="px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600">
+          Сохранить
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/posts/[id]/edit/page.tsx
+++ b/src/app/posts/[id]/edit/page.tsx
@@ -1,0 +1,10 @@
+import EditPostForm from './EditPostForm';
+
+export default async function EditPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <EditPostForm params={{ id }} />;
+}

--- a/src/app/posts/new/page.tsx
+++ b/src/app/posts/new/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function NewPostPage() {
+  const [photos, setPhotos] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const router = useRouter();
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const photoList = photos.split('\n').map((p) => p.trim()).filter(Boolean);
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photos: photoList, description, tags }),
+    });
+    if (res.ok) {
+      router.push('/');
+    }
+  }
+
+  return (
+    <div className="p-8 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold mb-4">Новый пост</h1>
+      <form className="flex flex-col gap-4" onSubmit={submit}>
+        <textarea
+          placeholder="Image URLs, one per line"
+          value={photos}
+          onChange={(e) => setPhotos(e.target.value)}
+          className="border p-2"
+        />
+        <textarea
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="text"
+          placeholder="Tags (comma separated)"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          className="border p-2"
+        />
+        <button type="submit" className="px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600">Создать</button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/PostsFeed.tsx
+++ b/src/components/PostsFeed.tsx
@@ -1,0 +1,105 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface Photo {
+  id: string;
+  url: string;
+}
+
+interface Post {
+  id: string;
+  description?: string | null;
+  tags?: string | null;
+  photos: Photo[];
+  user: {
+    id: string;
+    nickname?: string | null;
+    name?: string | null;
+    image?: string | null;
+  };
+}
+
+export default function PostsFeed({
+  initialPosts,
+  initialCursor,
+  currentUserId,
+}: {
+  initialPosts: Post[];
+  initialCursor?: string | null;
+  currentUserId?: string;
+}) {
+  const [posts, setPosts] = useState<Post[]>(initialPosts);
+  const [cursor, setCursor] = useState<string | undefined | null>(initialCursor);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+  const loadingRef = useRef(false);
+
+  useEffect(() => {
+    if (!loaderRef.current) return;
+    const ob = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && cursor && !loadingRef.current) {
+        loadingRef.current = true;
+        fetch(`/api/posts?cursor=${cursor}`)
+          .then((r) => (r.ok ? r.json() : null))
+          .then((data) => {
+            if (data) {
+              setPosts((p) => [...p, ...data.posts]);
+              setCursor(data.nextCursor);
+            }
+          })
+          .finally(() => {
+            loadingRef.current = false;
+          });
+      }
+    });
+    ob.observe(loaderRef.current);
+    return () => ob.disconnect();
+  }, [cursor]);
+
+  return (
+    <div className="space-y-4">
+      {posts.map((post) => (
+        <div key={post.id} className="border p-4 rounded">
+          <div className="flex items-center gap-2 mb-2">
+            {post.user.image && (
+              <Image
+                src={post.user.image}
+                alt="avatar"
+                width={32}
+                height={32}
+                className="rounded-full"
+              />
+            )}
+            <span>{post.user.nickname || post.user.name || post.user.id}</span>
+            {currentUserId === post.user.id && (
+              <Link
+                href={`/posts/${post.id}/edit`}
+                className="ml-auto text-sm text-blue-500"
+              >
+                Edit
+              </Link>
+            )}
+          </div>
+          {post.photos.length > 0 && (
+            <div className="flex gap-2 overflow-x-auto mb-2">
+              {post.photos.map((photo) => (
+                <Image
+                  key={photo.id}
+                  src={photo.url}
+                  alt="photo"
+                  width={200}
+                  height={200}
+                  className="object-cover"
+                />
+              ))}
+            </div>
+          )}
+          {post.description && <p className="mb-1">{post.description}</p>}
+          {post.tags && <p className="text-sm text-gray-500">{post.tags}</p>}
+        </div>
+      ))}
+      <div ref={loaderRef} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add pagination to posts API
- add API for editing individual posts
- create client `PostsFeed` with infinite scroll
- separate edit form under `/posts/[id]/edit`
- update homepage to use new feed component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841a4c44c4c83239ac1f7f309889696