### PR TITLE
Fix uploads route typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/mime": "^3.0.4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2962,6 +2963,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.4.tgz",
+      "integrity": "sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.9.0",
     "ethers": "^6.14.3",
+    "mime": "^3.0.0",
     "next": "15.3.3",
     "next-auth": "^4.24.11",
     "prisma": "^6.9.0",
@@ -21,12 +22,12 @@
     "react-dom": "^19.0.0",
     "siwe": "^3.0.0",
     "viem": "^2.30.6",
-    "wagmi": "^2.15.4",
-    "mime": "^3.0.0"
+    "wagmi": "^2.15.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/mime": "^3.0.4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -5,9 +5,10 @@ import mime from 'mime';
 
 export async function GET(
   req: Request,
-  { params }: { params: { path: string[] } }
+  { params }: { params: Promise<{ path: string[] }> }
 ) {
-  const filePath = path.join(process.cwd(), 'uploads', ...params.path);
+  const { path: pathParts } = await params;
+  const filePath = path.join(process.cwd(), 'uploads', ...pathParts);
   try {
     const data = await fs.readFile(filePath);
     const type = mime.getType(filePath) || 'application/octet-stream';


### PR DESCRIPTION
## Summary
- update uploads route param signature for new Next.js typed routes
- add `@types/mime` to satisfy TypeScript

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841ef7b4a088323afb073a33c39a061