### PR TITLE
Implement user blogs with personal feed

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -6,10 +6,12 @@ import { NextResponse } from 'next/server';
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const cursor = searchParams.get('cursor');
+  const userId = searchParams.get('userId');
   const take = 10;
   const posts = await prisma.post.findMany({
     take: take + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    ...(userId ? { where: { userId } } : {}),
     orderBy: { createdAt: 'desc' },
     include: {
       photos: true,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import Image from 'next/image';
 import Link from 'next/link';
+import PostsFeed from '@/components/PostsFeed';
 
 import { prisma } from '@/lib/db';
 
@@ -24,22 +25,37 @@ export default async function MyProfile() {
   });
   if (!user) return <p className="p-8">Profile not found</p>;
 
+  const take = 10;
+  const posts = await prisma.post.findMany({
+    take,
+    where: { userId: user.id },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      photos: true,
+      user: { select: { id: true, nickname: true, name: true, image: true } },
+    },
+  });
+  const nextCursor = posts.length === take ? posts[posts.length - 1].id : undefined;
+
   return (
-    <div className="p-8 max-w-xl mx-auto">
-      {user.image && (
-        <Image src={user.image} alt="avatar" width={80} height={80} className="rounded-full" />
-      )}
-      <h1 className="text-xl font-bold mt-4">{user.nickname || user.name || user.id}</h1>
-      {user.bio && <p className="mt-2">{user.bio}</p>}
-      {user.twitter && (
-        <p className="mt-2">Twitter: <a href={`https://twitter.com/${user.twitter}`}>{user.twitter}</a></p>
-      )}
-      {user.website && (
-        <p className="mt-2">Website: <a href={user.website}>{user.website}</a></p>
-      )}
-      <Link href="/profile/edit" className="inline-block mt-4 px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition">
-        Редактировать
-      </Link>
+    <div className="p-8 max-w-xl mx-auto space-y-6">
+      <div>
+        {user.image && (
+          <Image src={user.image} alt="avatar" width={80} height={80} className="rounded-full" />
+        )}
+        <h1 className="text-xl font-bold mt-4">{user.nickname || user.name || user.id}</h1>
+        {user.bio && <p className="mt-2">{user.bio}</p>}
+        {user.twitter && (
+          <p className="mt-2">Twitter: <a href={`https://twitter.com/${user.twitter}`}>{user.twitter}</a></p>
+        )}
+        {user.website && (
+          <p className="mt-2">Website: <a href={user.website}>{user.website}</a></p>
+        )}
+        <Link href="/profile/edit" className="inline-block mt-4 px-4 py-2 border rounded bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition">
+          Редактировать
+        </Link>
+      </div>
+      <PostsFeed initialPosts={posts} initialCursor={nextCursor} currentUserId={user.id} userId={user.id} />
     </div>
   );
 }

--- a/src/app/u/[id]/page.tsx
+++ b/src/app/u/[id]/page.tsx
@@ -1,5 +1,8 @@
 import { prisma } from '@/lib/db'
 import Image from 'next/image'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import PostsFeed from '@/components/PostsFeed'
 
 export default async function PublicProfile({
   params,
@@ -7,24 +10,49 @@ export default async function PublicProfile({
   params: Promise<{ id: string }>
 }) {
   const { id } = await params
-  const user = await prisma.user.findUnique({ where: { id } })
+  const [session, user] = await Promise.all([
+    getServerSession(authOptions),
+    prisma.user.findUnique({ where: { id } }),
+  ]);
+
+  const take = 10;
+  const posts = await prisma.post.findMany({
+    take,
+    where: { userId: id },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      photos: true,
+      user: { select: { id: true, nickname: true, name: true, image: true } },
+    },
+  });
+  const nextCursor = posts.length === take ? posts[posts.length - 1].id : undefined;
 
   if (!user) return <p className="p-8">User not found</p>;
   return (
-    <div className="p-8 max-w-xl mx-auto">
-      {user.image && <Image src={user.image} alt="avatar" width={80} height={80} className="rounded-full" />}
-      <h1 className="text-xl font-bold mt-4">{user.nickname || user.name || user.id}</h1>
-      {user.bio && <p className="mt-2">{user.bio}</p>}
-      {user.twitter && (
-        <p className="mt-2">
-          Twitter: <a href={`https://twitter.com/${user.twitter}`}>{user.twitter}</a>
-        </p>
-      )}
-      {user.website && (
-        <p className="mt-2">
-          Website: <a href={user.website}>{user.website}</a>
-        </p>
-      )}
+    <div className="p-8 max-w-xl mx-auto space-y-6">
+      <div>
+        {user.image && (
+          <Image src={user.image} alt="avatar" width={80} height={80} className="rounded-full" />
+        )}
+        <h1 className="text-xl font-bold mt-4">{user.nickname || user.name || user.id}</h1>
+        {user.bio && <p className="mt-2">{user.bio}</p>}
+        {user.twitter && (
+          <p className="mt-2">
+            Twitter: <a href={`https://twitter.com/${user.twitter}`}>{user.twitter}</a>
+          </p>
+        )}
+        {user.website && (
+          <p className="mt-2">
+            Website: <a href={user.website}>{user.website}</a>
+          </p>
+        )}
+      </div>
+      <PostsFeed
+        initialPosts={posts}
+        initialCursor={nextCursor}
+        currentUserId={(session?.user as { id?: string })?.id}
+        userId={id}
+      />
     </div>
   );
 }

--- a/src/components/PostsFeed.tsx
+++ b/src/components/PostsFeed.tsx
@@ -64,7 +64,7 @@ export default function PostsFeed({
   }, [cursor, uid]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 max-w-lg mx-auto">
       {posts.map((post) => (
         <div key={post.id} className="border p-4 rounded">
           <div className="flex items-center gap-2 mb-2">
@@ -96,8 +96,8 @@ export default function PostsFeed({
           {post.photos.length > 0 && (
             <ImageCarousel
               photos={post.photos}
-              width={200}
-              height={200}
+              width={480}
+              height={640}
               className="mb-2"
             />
           )}


### PR DESCRIPTION
## Summary
- support optional `userId` filter in posts API
- enable PostsFeed component to show posts for a specific user
- show list of own posts in profile page
- display posts on public profile pages
- link usernames to profile pages

## Testing
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6841fa38d930832384faf6d302a3bfea