### PR TITLE
Add Directus CMS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+
+## CMS (Directus)
+A minimal [Directus](https://directus.io) setup is included in the `directus` directory.
+
+```bash
+cd directus
+npm install
+cp .env.example .env
+npm start
+```
+
+This runs a local Directus instance using SQLite for storage.
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/directus/.env.example
+++ b/directus/.env.example
@@ -1,0 +1,6 @@
+KEY=ardents-directus
+SECRET=changeme
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=admin
+DB_CLIENT=sqlite3
+DB_FILENAME=./data.db

--- a/directus/.gitignore
+++ b/directus/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.db
+.env

--- a/directus/README.md
+++ b/directus/README.md
@@ -1,0 +1,26 @@
+# Directus CMS
+
+This directory contains a minimal setup for running the [Directus](https://directus.io) headless CMS alongside the existing Next.js application.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+cd directus
+npm install
+```
+
+2. Copy the example environment file and adjust credentials as needed:
+
+```bash
+cp .env.example .env
+```
+
+3. Start the CMS:
+
+```bash
+npm start
+```
+
+The CMS will create a `data.db` SQLite database inside this folder on first run. The default admin credentials are taken from the `.env` file.

--- a/directus/package.json
+++ b/directus/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ardents-directus",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "directus start"
+  },
+  "dependencies": {
+    "directus": "latest"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "prisma migrate deploy --schema=./prisma/schema.prisma && next start",
     "lint": "next lint",
     "prisma:generate": "prisma generate",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "cms": "npm --prefix directus start"
   },
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.7",


### PR DESCRIPTION
## Summary
- integrate a minimal Directus setup in `directus/`
- add README instructions for running the CMS
- provide environment example for Directus
- expose `npm run cms` script to start the CMS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842beea26448323ad1c79fcce2ba8e4